### PR TITLE
Sphinx zoom

### DIFF
--- a/docs/sphinx.rst
+++ b/docs/sphinx.rst
@@ -83,6 +83,14 @@ Step 2: Add references to models
 
 Now include ``diagram`` directives in your documents.
 
+Optionally you can configure Gaphor to make the generated diagrams links to the
+images. This might make sense if you have large diagrams that become unreadable
+due to the constraints of your Sphinx theme. To enable this feature set
+``gaphor_diagram_links`` to true:
+
+.. code:: python
+
+   gaphor_diagram_links = True
 
 Read the Docs
 ~~~~~~~~~~~~~

--- a/gaphor/extensions/tests/test_sphinx.py
+++ b/gaphor/extensions/tests/test_sphinx.py
@@ -27,8 +27,11 @@ def test_setup(tmp_path):
 
 
 def test_setup_load_models(tmp_path):
+    config = "gaphor_models = {'style-sheets': 'style-sheet-examples.gaphor'}\n"
+    config += "gaphor_diagram_links = True"
+
     (tmp_path / "conf.py").write_text(
-        "gaphor_models = {'style-sheets': 'style-sheet-examples.gaphor'}",
+        config,
         encoding="utf-8",
     )
     gen = sphinx.application.Sphinx(


### PR DESCRIPTION
Diagrams generated from a Gaphor model in Sphinx are sized according to the constraints of the theme applied. Large diagrams have the tendency to be unreadable in certain themes e.g. the ReadTheDocs theme. By wrapping the image node in a reference that points to the generated SVG file it provides a somewhat crude but effective mechanism to zoom in to the diagram.

Notes:
- The image directory is [defined at runtime](https://github.com/sphinx-doc/sphinx/blob/d5baa46d85edbb503beba98d82249b89236ca103/sphinx/builders/html/__init__.py#L222) in the Sphinx source code and AFAICT it's nigh impossible to retrieve this information from a Sphinx extension.
- I've added an additional configuration parameter as an enable flag with the default behavior being that no references are created. If there's consensus that this was too cautious the code can be simplified.

### PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I have read, and I am following the [Contributor guide](https://github.com/gaphor/gaphor/blob/main/CONTRIBUTING.md)
- [X] I have read, and I understand the GNOME [Code of Conduct](https://wiki.gnome.org/Foundation/CodeOfConduct)

### PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix
- [X] Feature
- [ ] Chore (refactoring, formatting, local variables, other cleanup)
- [ ] Documentation content changes

### What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently images are not 

Issue Number: N/A

### What is the new behavior?

### Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


### Other information
